### PR TITLE
Fixed the WorldGuard flag registration.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <packaging>jar</packaging>
 
     <name>CropClick</name>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
 
     <properties>
         <java.version>1.8</java.version>

--- a/src/main/java/com/github/bakuplayz/cropclick/CropClick.java
+++ b/src/main/java/com/github/bakuplayz/cropclick/CropClick.java
@@ -62,6 +62,7 @@ import lombok.Getter;
 import org.bukkit.Bukkit;
 import org.bukkit.command.PluginCommand;
 import org.bukkit.event.Listener;
+import org.bukkit.permissions.Permission;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -115,6 +116,23 @@ public final class CropClick extends JavaPlugin {
 
 
     /**
+     * Runs before the {@link #onEnable() execution of CropClick}.
+     */
+    @Override
+    public void onLoad() {
+        registerConfigs();
+        setupConfigs();
+
+        registerStorages();
+        setupStorages();
+
+        handleLegacyConfigs();
+
+        registerManagers();
+    }
+
+
+    /**
      * Starts the execution of {@link CropClick}.
      */
     @Override
@@ -127,19 +145,12 @@ public final class CropClick extends JavaPlugin {
 
         CropClick.plugin = this;
 
-        registerConfigs();
-        setupConfigs();
-
-        registerStorages();
-        setupStorages();
-
-        handleLegacyConfigs();
-
+        startUpdateFetchInterval();
         startStoragesSaveInterval();
 
-        registerManagers();
         registerCommands();
         registerListeners();
+        registerPermissions();
 
         loadConfigSections();
     }
@@ -270,9 +281,18 @@ public final class CropClick extends JavaPlugin {
      * Starts the saving interval for {@link DataStorage data storages}.
      */
     private void startStoragesSaveInterval() {
-        final int TEN_MINUTES_PERIOD = 10 * 60 * 20; // Written as Minecraft ticks.
-        Bukkit.getScheduler().runTaskTimerAsynchronously(this, farmData::saveData, 0, TEN_MINUTES_PERIOD);
-        Bukkit.getScheduler().runTaskTimerAsynchronously(this, worldData::saveData, 0, TEN_MINUTES_PERIOD);
+        final int TEN_MINUTES = 10 * 60 * 20; // Written as Minecraft ticks.
+        Bukkit.getScheduler().runTaskTimerAsynchronously(this, farmData::saveData, 0, TEN_MINUTES);
+        Bukkit.getScheduler().runTaskTimerAsynchronously(this, worldData::saveData, 0, TEN_MINUTES);
+    }
+
+
+    /**
+     * Starts fetching updates from the {@link CropClick CropClick's} update server.
+     */
+    private void startUpdateFetchInterval() {
+        final int THIRTHY_MINUTES = 30 * 60 * 20; // Written as Minecraft ticks.
+        Bukkit.getScheduler().runTaskTimerAsynchronously(this, updateManager::fetchUpdate, 0, THIRTHY_MINUTES);
     }
 
 
@@ -339,6 +359,14 @@ public final class CropClick extends JavaPlugin {
         manager.registerEvents(new AutofarmLinkListener(this), this);
 
         manager.registerEvents(new EntityDestroyAutofarmListener(this), this);
+    }
+
+
+    /**
+     * Registers all the {@link Permission permissions}.
+     */
+    private void registerPermissions() {
+        permissionManager.registerPermissions(this);
     }
 
 }

--- a/src/main/java/com/github/bakuplayz/cropclick/addons/addon/WorldGuardAddon.java
+++ b/src/main/java/com/github/bakuplayz/cropclick/addons/addon/WorldGuardAddon.java
@@ -27,7 +27,6 @@ import com.sk89q.worldguard.WorldGuard;
 import com.sk89q.worldguard.domains.DefaultDomain;
 import com.sk89q.worldguard.protection.ApplicableRegionSet;
 import com.sk89q.worldguard.protection.flags.StateFlag;
-import com.sk89q.worldguard.protection.flags.registry.FlagRegistry;
 import com.sk89q.worldguard.protection.managers.RegionManager;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import com.sk89q.worldguard.protection.regions.RegionContainer;
@@ -62,8 +61,7 @@ public final class WorldGuardAddon extends Addon {
      * Registers the {@link #cropFlag CropClick flag}.
      */
     private void registerFlag() {
-        FlagRegistry registry = worldGuard.getFlagRegistry();
-        registry.register(cropFlag);
+        worldGuard.getFlagRegistry().register(cropFlag);
     }
 
 

--- a/src/main/java/com/github/bakuplayz/cropclick/permissions/PermissionManager.java
+++ b/src/main/java/com/github/bakuplayz/cropclick/permissions/PermissionManager.java
@@ -59,6 +59,18 @@ public final class PermissionManager {
 
         registerCommands();
 
+
+    }
+
+
+    /**
+     * Registers all the {@link Permission permissions} for {@link CropClick}.
+     *
+     * @param plugin the plugin instance.
+     */
+    public void registerPermissions(CropClick plugin) {
+        registerCommands();
+
         /* Runs once the server is done loading in order to register all crops,
          * both CropClick's and other plugins. */
         Bukkit.getScheduler().runTaskLater(plugin, this::registerCrops, 0);

--- a/src/main/java/com/github/bakuplayz/cropclick/update/UpdateManager.java
+++ b/src/main/java/com/github/bakuplayz/cropclick/update/UpdateManager.java
@@ -30,7 +30,6 @@ import com.google.gson.JsonObject;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
-import org.bukkit.Bukkit;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -65,8 +64,6 @@ public final class UpdateManager {
         setUpdateMessage("");
         setUpdateTitle("");
         this.plugin = plugin;
-
-        fetchUpdates();
     }
 
 
@@ -117,22 +114,9 @@ public final class UpdateManager {
 
 
     /**
-     * Starts fetching updates from the {@link #UPDATE_URL update server}.
-     */
-    private void fetchUpdates() {
-        Bukkit.getScheduler().runTaskTimerAsynchronously(
-                plugin,
-                this::fetchUpdate,
-                0, // ticks before running the first time.
-                60 * 30 * 20  // ticks before running again (30 minutes as ticks).
-        );
-    }
-
-
-    /**
      * Fetches the updates from the {@link #UPDATE_URL update server}.
      */
-    private void fetchUpdate() {
+    public void fetchUpdate() {
         try {
             JsonElement response = new HttpRequestBuilder(UPDATE_URL)
                     .setDefaultHeaders()


### PR DESCRIPTION
Changes:
* ``Created an onLoad() and moved the registration of configurations, storages and managers there.``
* ``Changed the way permissions are handled, and the way updates are handled.``
* ``Added documentation and reformatted code that required that.``

Issues:
* Fixes #80 for the latest versions.
* Closes #80.
* Patched in version 2.0.1 of CropClick.